### PR TITLE
Fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/assemble/prettify.git"
+    "url": "https://github.com/helpers/prettify.git"
   },
   "bugs": {
     "url": "https://github.com/helpers/prettify/issues"


### PR DESCRIPTION
It was pointing to a repo under assemble that didn't exist
